### PR TITLE
one-liner change to detect strings in IDA Version 7.0+

### DIFF
--- a/tiknib/ida/fetch_funcdata_v7.5.py
+++ b/tiknib/ida/fetch_funcdata_v7.5.py
@@ -45,7 +45,7 @@ def get_strings(start_addr, end_addr):
         for ref in refs:
             t = idc.get_str_type(ref)
             if isinstance(t, int) and t >= 0:
-                s = idc.get_strlit_contents(ref)
+                s = idc.get_strlit_contents(ref).decode('latin-1')
                 if s and isprintable(s):
                     strings.append([h, s, t, ref])
     return strings


### PR DESCRIPTION
since function _get_strlit_contents_ returns its result in form of a bytes object, it needs decoding before getting passed to the if statement which checks whether the string is printable or not.